### PR TITLE
Localstack plugin

### DIFF
--- a/plugins/localstack/api_key.go
+++ b/plugins/localstack/api_key.go
@@ -1,0 +1,70 @@
+package localstack
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://localstack.com/docs/api_key"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.localstack.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to LocalStack.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 10,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryLocalStackConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"LOCALSTACK_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the API Key in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryLocalStackConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.APIKey == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.APIKey: config.APIKey,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	APIKey string
+// }

--- a/plugins/localstack/api_key.go
+++ b/plugins/localstack/api_key.go
@@ -1,8 +1,6 @@
 package localstack
 
 import (
-	"context"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -14,8 +12,8 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://localstack.com/docs/api_key"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.localstack.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://docs.localstack.cloud/getting-started/api-key/"),
+		ManagementURL: sdk.URL("https://app.localstack.cloud/account/apikeys"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
@@ -34,37 +32,9 @@ func APIKey() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
-			TryLocalStackConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"LOCALSTACK_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+	"LOCALSTACK_API_KEY": fieldname.APIKey,
 }
-
-// TODO: Check if the platform stores the API Key in a local config file, and if so,
-// implement the function below to add support for importing it.
-func TryLocalStackConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-		// var config Config
-		// if err := contents.ToYAML(&config); err != nil {
-		// 	out.AddError(err)
-		// 	return
-		// }
-
-		// if config.APIKey == "" {
-		// 	return
-		// }
-
-		// out.AddCandidate(sdk.ImportCandidate{
-		// 	Fields: map[sdk.FieldName]string{
-		// 		fieldname.APIKey: config.APIKey,
-		// 	},
-		// })
-	})
-}
-
-// TODO: Implement the config file schema
-// type Config struct {
-//	APIKey string
-// }

--- a/plugins/localstack/api_key_test.go
+++ b/plugins/localstack/api_key_test.go
@@ -2,12 +2,12 @@ package localstack
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {

--- a/plugins/localstack/api_key_test.go
+++ b/plugins/localstack/api_key_test.go
@@ -1,0 +1,55 @@
+package localstack
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "SzCEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"LOCALSTACK_API_KEY": "SzCEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"LOCALSTACK_API_KEY": "SzCEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "SzCEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in localstack/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "SzCEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/localstack/api_key_test.go
+++ b/plugins/localstack/api_key_test.go
@@ -11,7 +11,7 @@ import (
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.APIKey: "SzCEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -26,7 +26,7 @@ func TestAPIKeyProvisioner(t *testing.T) {
 func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
+			Environment: map[string]string{
 				"LOCALSTACK_API_KEY": "SzCEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
@@ -35,20 +35,6 @@ func TestAPIKeyImporter(t *testing.T) {
 						fieldname.APIKey: "SzCEXAMPLE",
 					},
 				},
-			},
-		},
-		// TODO: If you implemented a config file importer, add a test file example in localstack/test-fixtures
-		// and fill the necessary details in the test template below.
-		"config file": {
-			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
-			},
-			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "SzCEXAMPLE",
-			// 		},
-			// 	},
 			},
 		},
 	})

--- a/plugins/localstack/localstack.go
+++ b/plugins/localstack/localstack.go
@@ -1,0 +1,25 @@
+package localstack
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func LocalStackCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "LocalStack CLI", // TODO: Check if this is correct
+		Runs:      []string{"localstack"},
+		DocsURL:   sdk.URL("https://localstack.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/localstack/localstack.go
+++ b/plugins/localstack/localstack.go
@@ -9,9 +9,9 @@ import (
 
 func LocalStackCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "LocalStack CLI", // TODO: Check if this is correct
+		Name:      "LocalStack CLI",
 		Runs:      []string{"localstack"},
-		DocsURL:   sdk.URL("https://localstack.com/docs/cli"), // TODO: Replace with actual URL
+		DocsURL:   sdk.URL("https://docs.localstack.cloud/getting-started/installation/#localstack-cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/localstack/localstack.go
+++ b/plugins/localstack/localstack.go
@@ -9,9 +9,9 @@ import (
 
 func LocalStackCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "LocalStack CLI",
-		Runs:      []string{"localstack"},
-		DocsURL:   sdk.URL("https://docs.localstack.cloud/getting-started/installation/#localstack-cli"),
+		Name:    "LocalStack CLI",
+		Runs:    []string{"localstack"},
+		DocsURL: sdk.URL("https://docs.localstack.cloud/getting-started/installation/#localstack-cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/localstack/plugin.go
+++ b/plugins/localstack/plugin.go
@@ -1,0 +1,22 @@
+package localstack
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "localstack",
+		Platform: schema.PlatformInfo{
+			Name:     "LocalStack",
+			Homepage: sdk.URL("https://localstack.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			LocalStackCLI(),
+		},
+	}
+}

--- a/plugins/localstack/plugin.go
+++ b/plugins/localstack/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "localstack",
 		Platform: schema.PlatformInfo{
 			Name:     "LocalStack",
-			Homepage: sdk.URL("https://localstack.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://localstack.cloud"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience


## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

`localstack start`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


